### PR TITLE
Label Unknown as Unknown

### DIFF
--- a/parsnip/instruments.py
+++ b/parsnip/instruments.py
@@ -324,6 +324,7 @@ def parse_ztf(dataset, reject_invalid=True, verbose=True):
         'unclassified': 'Unknown',
         'unk': 'Unknown',
         'unknown': 'Unknown',
+        'Unknown': 'Unknown',
         'varstar': 'Star',
     }
 


### PR DESCRIPTION
If one creates `lcdata.Dataset` without explicit `type` value of metadata, than the `Unknown` value is used as a default
https://github.com/kboone/lcdata/blob/v1.1.1/lcdata/lightcurve.py#L85

This causes problems inside `parse_ztf` problems, because 'Unknown' is not a key of `label_map`. This commit fixes
this problem adding 'Unknown': 'Unknown' mapping into this dict