### PR TITLE
Replace NaN grads with zero

### DIFF
--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -20,7 +20,7 @@ from torch.utils.data import DataLoader
 
 from .light_curve import preprocess_light_curve, grid_to_time, time_to_grid, \
     SIDEREAL_SCALE
-from .utils import frac_to_mag, parse_device
+from .utils import frac_to_mag, parse_device, replace_nan_grads
 from .settings import parse_settings, default_model
 from .sncosmo import ParsnipSncosmoSource
 
@@ -1234,6 +1234,7 @@ class ParsnipModel(nn.Module):
                         loss = self.loss_function(result)
 
                         loss.backward()
+                        replace_nan_grads(self.parameters())
                         train_loss += loss.item()
                         self.optimizer.step()
 

--- a/parsnip/utils.py
+++ b/parsnip/utils.py
@@ -68,3 +68,20 @@ def parse_device(device):
         use_device = 'cpu'
 
     return use_device
+
+
+def replace_nan_grads(parameters, value=0.0):
+    """Replace NaN gradients
+
+    Parameters
+    ----------
+    parameters : Iterator[torch.Tensor]
+        Model parameters, usually you can get them by `model.parameters()`
+    value : float, optional
+        Value to replace NaNs with
+    """
+    for p in parameters:
+        if p.grad is None:
+            continue
+        grads = p.grad.data
+        grads[torch.isnan(grads)] = value


### PR DESCRIPTION
I found that sometimes NaN gradient values appears, probably it is caused by a back-prop through the physical layer. I've found that an appropriate practical solution is just replacing NaNs with zeros.