### PR TITLE
Fix device selection for cuda

### DIFF
--- a/parsnip/utils.py
+++ b/parsnip/utils.py
@@ -68,6 +68,8 @@ def parse_device(device):
     if device == 'cpu':
         # Requested CPU.
         use_device = 'cpu'
+    elif device == 'cuda' and torch.cuda.is_available():
+        use_device = 'cuda'
     elif device_available:
         use_device = device
     else:


### PR DESCRIPTION
I'm sorry, but my previous PR #8 introduced a bug on detecting CUDA devices: `torch.backends.cuda` is different from other backends and doesn't have is_available() function. This PR fixes it, I believe I properly tested it this time