### PR TITLE
Modernize dependencies

### DIFF
--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -1847,7 +1847,7 @@ def load_model(path=None, device='cpu', threads=8):
 
     # Load the model data
     use_device = parse_device(device)
-    settings, state_dict = torch.load(path, use_device)
+    settings, state_dict = torch.load(path, use_device, weights_only=False)
 
     # Instantiate the model
     model = ParsnipModel(path, settings['bands'], use_device, threads, settings)

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -187,7 +187,7 @@ class ParsnipModel(nn.Module):
         else:
             raise ValueError('Unknown optimizer "{}"'.format(self.settings['optimizer']))
         self.scheduler = optim.lr_scheduler.ReduceLROnPlateau(
-            self.optimizer, factor=self.settings['scheduler_factor'], verbose=True
+            self.optimizer, factor=self.settings['scheduler_factor']
         )
 
         # Send the model weights to the desired device

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     astropy
     extinction
     lcdata>=1.1.1
-    lightgbm>=2.3.1,<3
+    lightgbm>=2.3.1
     matplotlib
     numpy
     scikit-learn

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = astro-parsnip
-version = 1.4.2
+version = 1.4.3
 author = Kyle Boone
 author_email = kyboone@uw.edu
 description = Deep generative modeling of astronomical transient light curves


### PR DESCRIPTION
This PR addresses compatibility issues with modern versions of PyTorch, LightGBM, and the Python standard library that have made it increasingly difficult to install dependencies with recent versions of Python.

* Remove version cap on `lightgbm` for compatibility with LightGBM >= 4.
* Remove the `verbose=True` argument from the learning rate scheduler initialization for compatibility with PyTorch>=2.6
* Load models with `weights_only=False` for compatibility with PyTorch>=2.6
* Switch from `pkg_resources` to `importlib.resources` for compatibility with the Python 3.12 standard library.
