### PR TITLE
Require Python 3.9

### DIFF
--- a/docs/boone2021.rst
+++ b/docs/boone2021.rst
@@ -107,6 +107,6 @@ Figures and analysis
 ====================
 
 All of the figures and analysis in Boone 2021 were done with `Jupyter notebooks that are
-available on GitHub <https://github.com/kboone/parsnip/tree/main/notebooks>`_. To rerun
+available on GitHub <https://github.com/LSSTDESC/parsnip/tree/main/notebooks>`_. To rerun
 these notebooks, copy the notebooks folder to the working directory and run the
 notebooks from within that folder.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,4 +19,4 @@ estimation, and identifying novel transients.
    photoz
    reference
 
-Source code: https://github.com/kboone/parsnip
+Source code: https://github.com/LSSTDESC/parsnip

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ ParSNIP requires Python 3.6+ and depends on the following Python packages:
 
 - `astropy <http://www.astropy.org>`_
 - `extinction <https://github.com/kbarbary/extinction>`_
-- `lcdata <https://github.com/kboone/lcdata>`_
+- `lcdata <https://github.com/LSSTDESC/lcdata>`_
 - `lightgbm <https://lightgbm.readthedocs.io/en/latest/>`_
 - `matplotlib <https://matplotlib.org>`_
 - `numpy <http://www.numpy.org>`_
@@ -26,10 +26,10 @@ ParSNIP is available on PyPI. To install the latest release::
 Install development version
 ===========================
 
-The ParSNIP source code can be found on `github <https://github.com/kboone/parsnip>`_.
+The ParSNIP source code can be found on `github <https://github.com/LSSTDESC/parsnip>`_.
 
 To install it::
 
-    git clone git://github.com/kboone/parsnip
+    git clone git://github.com/LSSTDESC/parsnip
     cd parsnip
     pip install -e .

--- a/docs/photoz.rst
+++ b/docs/photoz.rst
@@ -72,6 +72,6 @@ Figures and analysis
 
 All of the figures and analysis in Boone et al. 2022 (in prep.) can be reproduced with
 `a Jupyter notebook that is available on GitHub
-<https://github.com/kboone/parsnip/tree/main/notebooks/photoz.ipynb>`_. To rerun this
+<https://github.com/LSSTDESC/parsnip/tree/main/notebooks/photoz.ipynb>`_. To rerun this
 notebook on a newly trained model, copy the notebooks folder to the working directory
 and run the notebook from within that folder.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -108,7 +108,7 @@ Plot the predicted spectrum at a given time::
 
 See the :doc:`reference` page for a list of all of the built-in methods, or the
 `notebooks that were used to make figures for Boone et al.
-2021 <https://github.com/kboone/parsnip/tree/main/notebooks>`_ for examples.
+2021 <https://github.com/LSSTDESC/parsnip/tree/main/notebooks>`_ for examples.
 
 Classifying light curves
 ========================
@@ -145,4 +145,4 @@ The classifier can the be used to generate predictions for a new dataset with::
           ...   ...   ...   ...   ...   ...
 
 For more details and examples, see the `classification demo notebook
-<https://github.com/kboone/parsnip/blob/main/notebooks/classification.ipynb>`_.
+<https://github.com/LSSTDESC/parsnip/blob/main/notebooks/classification.ipynb>`_.

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ description = Deep generative modeling of astronomical transient light curves
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/kboone/parsnip
+license = MIT
 classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License
@@ -14,7 +15,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
     astropy
     extinction

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ author_email = kyboone@uw.edu
 description = Deep generative modeling of astronomical transient light curves
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/kboone/parsnip
+url = https://github.com/LSSTDESC/parsnip
 license = MIT
 classifiers =
     Programming Language :: Python :: 3


### PR DESCRIPTION
PR #21 requires python 3.9 due to usage of `importlib.resources.as_file`. 

I also add License (MIT) here and update all the github links to point to LSSTDESC organization